### PR TITLE
Add an error listener to prevent socket hang up and similar errors leading to thrown exceptions.

### DIFF
--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -128,6 +128,14 @@ client.prototype.request = function(method, path, params, callback){
         });
     });
 
+    // This should only occur for errors such as a socket hang up prior to any
+    // data being received, or SSL-related issues.
+    req.on('error', function(err) {
+        if(typeof callback == 'function'){
+            callback(err, null, 0);
+        }
+    });
+
     if(['POST', 'PUT'].indexOf(http_options['method']) >= 0){
         req.write(body);
     }


### PR DESCRIPTION
Socket hang ups and SSL issues can cause a thrown exception, e.g. if a DataDog API server glitches at just the right time. We have seen this happen intermittently.

The way to prevent this from throwing is to add an `error` event handler to the request, so that the error is passed to the callback as expected.
