### PR TITLE
Fixed issue with date not being rounded to seconds on event add

### DIFF
--- a/lib/api/event.js
+++ b/lib/api/event.js
@@ -136,7 +136,7 @@ event_api.prototype.add_event = function(event, callback){
     }
 
     if(!event['date_happened']){
-        event['date_happened'] = (new Date().getTime()) / 1000;
+        event['date_happened'] = Math.round((new Date()).getTime() / 1000);
     }
 
     if(event['priority']){


### PR DESCRIPTION
DataDog API requires the current time in UTC to be rounded to the nearest Second.  We must explicitly call the Math.round() to ensure that we are correctly rounded to the nearest seconds.  Here is a dump of the console to see what we get from the original line and the modification:

>  x = new Date().getTime()
> 1403558949292
> x / 1000
> 1403558949.292
>  Math.round((x / 1000))
> 1403558949

Notice that just dividing the output of Date().getTime() by 1000 does not round to the nearest second.  Instead it returns a floating point number.  We solve this by calling Math.round()
