### PR TITLE
Add snapshot status

### DIFF
--- a/lib/api/snapshot.js
+++ b/lib/api/snapshot.js
@@ -72,4 +72,30 @@ snapshot_api.prototype.add_snapshot_from_def = function(snapshot, callback){
     this.request('GET', '/graph/snapshot', {query: snapshot}, callback);
 };
 
+snapshot_api.prototype.snapshot_status = function(snapshot_url, callback){
+    /*
+     * snapshot_api.add_snapshot(snapshot_url, [callback])
+     *
+     * method used to check the status of a datadog snapshot.
+     * https://github.com/DataDog/dogapi/blob/master/src/dogapi/http/snapshot.py#L64
+     * Snapshot URLs are returned right away, but may be empty if the query or graph is complicated.
+     * Result will be a json payload, with 403 for incomplete, or 200 for complete.
+     * Examples:
+     *  * {"status_code":403} - incomplete (still processing, image is empty)
+     *  * {"status_code":200} - image is rendered and ready
+     *
+     * `snapshot_url` is a string containing URL returned from a call to add_snapshot or add_snapshot_from_def
+     *
+     * `callback` is an optional function for the result
+     *     callback(error, result, status_code)
+    */
+    if(typeof snapshot_url != 'string'){
+        throw new Error('`snapshot_url` parameter must be a string');
+    }
+
+    url = snapshot_url.split('/snapshot/view/')[1].split('.png')[0]
+
+    this.request('GET', '/graph/snapshot_status/'+url, {}, callback);
+};
+
 return module.exports = snapshot_api;


### PR DESCRIPTION
@brettlangdon Hi again, more snapshot API love from me.

This adds the snapshot_status endpoint. Some complicated graphs (particularly from graph_def) will take more than a second to process, and if you fetch the URL right away you get an empty image. This implements their official API for checking a snapshot's status.

https://github.com/DataDog/dogapi/blob/master/src/dogapi/http/snapshot.py#L64