### PR TITLE
Fix json big int issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.11"
+  - "0.10"
+  - "iojs"
+  - "iojs-v1.0.4"
+  - "stable"

--- a/bin/dogapi
+++ b/bin/dogapi
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var dogapi = require("../");
+var json = require("../lib/json");
 var minimist = require("minimist");
 var rc = require("rc");
 
@@ -56,13 +57,13 @@ if(command === "now"){
     if(subcommand){
         dogapi[command].handleCli(subcommand, args, function(err, res){
             if(err){
-                console.error(JSON.stringify(err, null, '  '));
+                console.error(json.stringify(err, null, '  '));
                 process.exit(1);
             } else {
                 if(res === ""){
                     res = "success";
                 }
-                console.log(JSON.stringify(res, null, '  '));
+                console.log(json.stringify(res, null, '  '));
             }
         });
     } else {

--- a/lib/api/screenboard.js
+++ b/lib/api/screenboard.js
@@ -1,4 +1,5 @@
 var client = require("../client");
+var json = require("../json");
 var util = require("util");
 
 
@@ -218,11 +219,11 @@ module.exports = {
         } else if(subcommand === "create"){
             var title = args._[4];
             var description = args._[5];
-            var graphs = JSON.parse(args._[6]);
+            var graphs = json.parse(args._[6]);
 
             var options = {};
             if(args["tmpvars"]){
-                options.templateVariables = JSON.parse(args["tmpvars"]);
+                options.templateVariables = json.parse(args["tmpvars"]);
             }
             if(args["width"]){
                 options.width = parseInt(args["width"]);

--- a/lib/api/timeboard.js
+++ b/lib/api/timeboard.js
@@ -166,7 +166,7 @@ function update(dashId, title, description, graphs, templateVariables, callback)
  *  ```
  */
 function remove(dashId, callback){
-    client.request("DELETE", util.format("/dash/%s", dashId), params, callback);
+    client.request("DELETE", util.format("/dash/%s", dashId), {}, callback);
 }
 
 /*section: timeboard
@@ -187,7 +187,7 @@ function remove(dashId, callback){
  *  ```
  */
 function getAll(callback){
-    client.request("GET", "/dash", params, callback);
+    client.request("GET", "/dash", {}, callback);
 }
 
 /*section: timeboard
@@ -209,7 +209,7 @@ function getAll(callback){
  *  ```
  */
 function get(dashId, callback){
-    client.request("GET", util.format("/dash/%s", dashId), params, callback);
+    client.request("GET", util.format("/dash/%s", dashId), {}, callback);
 }
 
 module.exports = {

--- a/lib/api/timeboard.js
+++ b/lib/api/timeboard.js
@@ -1,4 +1,5 @@
 var client = require("../client");
+var json = require("../json");
 var util = require("util");
 
 /*section: timeboard
@@ -249,10 +250,10 @@ module.exports = {
         } else if(subcommand === "create"){
             var title = args._[4];
             var description = args._[5];
-            var graphs = JSON.parse(args._[6]);
+            var graphs = json.parse(args._[6]);
             var templateVariables = [];
             if(args["tmpvars"]){
-                templateVariables = JSON.parse(args["tmpvars"]);
+                templateVariables = json.parse(args["tmpvars"]);
             }
 
             create(title, description, graphs, templateVariables, callback);
@@ -260,10 +261,10 @@ module.exports = {
             var dashId = parseInt(args._[4]);
             var title = args._[5];
             var description = args._[6];
-            var graphs = JSON.parse(args._[7]);
+            var graphs = json.parse(args._[7]);
             var templateVariables = [];
             if(args["tmpvars"]){
-                templateVariables = JSON.parse(args["tmpvars"]);
+                templateVariables = json.parse(args["tmpvars"]);
             }
 
             update(dashId, title, description, graphs, templateVariables, callback);

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
 var extend = require("extend");
 var https = require("https");
+var json = require("./json");
 var url = require("url");
 var util = require("util");
 
@@ -50,7 +51,7 @@ client.prototype.request = function(method, path, params, callback){
     }
 
     params = params || {};
-    var body = (typeof params["body"] === "object")? JSON.stringify(params["body"]) : params["body"];
+    var body = (typeof params["body"] === "object")? json.stringify(params["body"]) : params["body"];
     var query = {
         "api_key": this.api_key,
         "application_key": this.app_key,
@@ -97,7 +98,7 @@ client.prototype.request = function(method, path, params, callback){
 
         res.on("end", function(){
             var error = null;
-            try{ data = JSON.parse(data); }catch(e){}
+            try{ data = json.parse(data); }catch(e){}
             if(data["errors"]){
                 error = data["errors"];
                 data = null;

--- a/lib/json.js
+++ b/lib/json.js
@@ -1,0 +1,7 @@
+var JSONBig = require("json-bigint");
+
+
+module.exports = {
+  stringify: JSONBig.stringify,
+  parse: JSONBig.parse
+};

--- a/lib/json.js
+++ b/lib/json.js
@@ -2,6 +2,6 @@ var JSONBig = require("json-bigint");
 
 
 module.exports = {
-  stringify: JSONBig.stringify,
-  parse: JSONBig.parse
+    stringify: JSONBig.stringify,
+    parse: JSONBig.parse
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "gitHead": "f388635a5ab4f4da25702dc0999385d437bdf2bc",
   "dependencies": {
     "extend": "^2.0.0",
+    "json-bigint": "^0.1.4",
     "minimist": "^1.1.1",
     "rc": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Datadog API Node.JS Client",
   "main": "lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "./node_modules/.bin/mocha ./test",
     "docs": "node ./docs/create.js > index.html"
   },
   "bin": {
@@ -38,9 +38,11 @@
     "rc": "^1.0.0"
   },
   "devDependencies": {
+    "bignumber.js": "^2.0.7",
     "docast": "^0.1.1",
     "glob": "^5.0.3",
     "js-yaml": "^3.2.7",
-    "marked": "^0.3.3"
+    "marked": "^0.3.3",
+    "mocha": "^2.2.5"
   }
 }

--- a/test/json.js
+++ b/test/json.js
@@ -1,0 +1,26 @@
+var assert = require("assert");
+var BigNumber = require("bignumber.js");
+var json = require("../lib/json");
+
+describe("json", function(){
+    describe("#parse()", function(){
+        it("should properly parse big integers", function(){
+            // DEV: This test case is from: https://github.com/brettlangdon/node-dogapi/issues/16
+            var data = "{\"id\": 2868860079149422351}";
+            var parsed = json.parse(data);
+            // `parsed.id` is an instance of `BigNumber`
+            assert.equal(parsed.id.toString(), "2868860079149422351");
+        });
+    });
+
+    describe("#stringify()", function(){
+        it("should properly parse big integers", function(){
+            // DEV: This test case is from: https://github.com/brettlangdon/node-dogapi/issues/16
+            var data = {"id": new BigNumber('2868860079149422351')};
+            var stringified = json.stringify(data);
+            // Yeah, it ends up being a string and not an int, but mostly we
+            // want to make sure it doesn't throw an error or provide the wrong number
+            assert.equal(stringified, "{\"id\":\"2868860079149422351\"}");
+        });
+    });
+});


### PR DESCRIPTION
This should resolve #16 

The fix was to use `json-bigint` for parsing/stringify. This ensures that any large json integers will get parsed as a `BigNumber` (from `bignumber.js`).

The only downside is when you try to stringify a `BigNumber` it will get coerced into a string rather than an integer :/