### PR TITLE
Fix bug with `metric.send` call not sending `points` in the proper format

### DIFF
--- a/lib/api/metric.js
+++ b/lib/api/metric.js
@@ -38,6 +38,22 @@ function send(metric, points, extra, callback){
         callback = extra;
         extra = {};
     }
+    // Try to normalize `points`
+    // DEV: We need `points` to be an array of arrays regardless of what they give us
+    // Always wrap points in an array, this way we will get:
+    //   500 => [500]
+    //   [<timestamp>, 500] => [[<timestamp>, 500]]
+    points = [points];
+    points = points.map(function(point){
+        // Make sure each point is an array, if not make array with current timestamp
+        //   500 => [<timestamp>, 500]
+        //   [<timestamp>, 500] => unchanged
+        if(!Array.isArray(point)){
+            var now = parseInt(new Date().getTime() / 1000);
+            point = [now, point];
+        }
+        return point;
+    });
 
     extra = extra || {};
     var series = [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Datadog API Node.JS Client",
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha ./test",
+    "test": "./node_modules/.bin/mocha --recursive ./test",
     "docs": "node ./docs/create.js > index.html"
   },
   "bin": {
@@ -43,6 +43,7 @@
     "glob": "^5.0.3",
     "js-yaml": "^3.2.7",
     "marked": "^0.3.3",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "sinon": "^1.15.4"
   }
 }

--- a/test/api/metric.js
+++ b/test/api/metric.js
@@ -1,0 +1,83 @@
+var assert = require("assert");
+var client = require("../../lib/client");
+var extend = require("extend");
+var metric = require("../../lib/api/metric");
+var sinon = require("sinon");
+
+describe("api/metrics", function(){
+    var stub_request;
+    beforeEach(function(){
+        // Setup `client.request` as a stub
+        stub_request = sinon.stub(client, "request");
+    });
+    afterEach(function(){
+        // Reset the original `client.request`
+        stub_request.restore();
+        stub_request = null;
+    });
+    describe("#send", function(){
+        it("should make a valid api call", function(){
+            // Make our api call
+            var now = parseInt(new Date().getTime() / 1000);
+            metric.send("metric.send", [now, 500]);
+
+            // Assert we properly called `client.request`
+            assert(stub_request.calledOnce);
+            var call_args = stub_request.getCall(0).args;
+            // Method and endpoint are correct
+            assert.equal(call_args[0], "POST");
+            assert.equal(call_args[1], "/series");
+
+            // Properly formatted body
+            // { body: series: [ {metric: "metric.send", host: undefined, tags: undefined, metric_type: undefined} ] }
+            // DEV: host/tags/metric_type are optional and should be undefined for this case
+            var data = call_args[2];
+            assert(data.hasOwnProperty("body"));
+            assert(data.body.hasOwnProperty("series"));
+
+            // Assert we have only 1 series
+            // series = [ {metric: "", ...}, ... ]
+            var series = data.body.series;
+            assert(Array.isArray(series));
+            assert.equal(series.length, 1);
+
+            // Assert the first series is properly formatted
+            // first_series = {metric: "", points: [], ...}
+            var first_series = series[0]
+            assert.equal(first_series.metric, "metric.send");
+            assert(Array.isArray(first_series.points));
+            assert.deepEqual(first_series.points, [[now, 500]]);
+
+            // These keys are optional and should be set, but undefined
+            assert(first_series.hasOwnProperty("host"));
+            assert.equal(first_series.host, undefined);
+            assert(first_series.hasOwnProperty("tags"));
+            assert.equal(first_series.tags, undefined);
+            assert(first_series.hasOwnProperty("metric_type"));
+            assert.equal(first_series.metric_type, undefined);
+        });
+
+        it("should properly normalize values to points", function(){
+            // Make our api call
+            metric.send("metrics.send.normalize", 500);
+
+            // Assert we called `client.request` with the correct `points`
+            assert(stub_request.calledOnce);
+            var call_args = stub_request.getCall(0).args;
+            // { body: series: [ {points: [], }, ] }
+            var body = call_args[2].body;
+            assert.equal(body.series.length, 1);
+
+            // points = [ [<timestamp>, 500] ]
+            var points = body.series[0].points;
+            assert(Array.isArray(points));
+            assert.equal(points.length, 1);
+
+            // point = [<timestamp>, 500]
+            var point = points[0];
+            assert(Array.isArray(point));
+            assert.equal(point.length, 2);
+            assert.equal(point[1], 500);
+        });
+    });
+});


### PR DESCRIPTION
See #20 for bug report and repo steps.