### PR TITLE
Add support for the /search endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@ document.addEventListener("DOMContentLoaded", function(){hljs.initHighlightingOn
 </li>
 <li role=""><a href="#screenboard">screenboard</a>
 </li>
+<li role=""><a href="#search">search</a>
+</li>
 <li role=""><a href="#serviceCheck">serviceCheck</a>
 </li>
 <li role=""><a href="#tag">tag</a>
@@ -1211,6 +1213,41 @@ var options = {
 };
 dogapi.initialize(options);
 dogapi.screenboard.share(1234, function(err, res){
+  console.dir(res);
+});
+</code></pre>
+</div>
+</div>
+</section>
+<section id="search" class="col-sm-12">
+<div class="row">
+<h2 class="bg-primary" style="text-indent:1rem">search</h2></div>
+<ul class="nav nav-pills">
+<li role"presentation"><a href="#search-search">search</a></li>
+</ul>
+<div class="function row" id="search-search">
+<h3 class="bg-info" style="text-indent:.5rem;padding:.5rem;margin-top:.5rem">search(query, callback)</h3>
+<div class="col-md-6">
+<p>search for metrics and hosts from the past 24 hours</p>
+<h4>Parameters:</h4>
+<dl>
+<dt>query</dt>
+<dd><p>the seach query to perform (e.g. &quot;app1&quot; or &quot;hosts:app1&quot; or &quot;metrics:response&quot;)</p>
+</dd>
+<dt>callback</dt>
+<dd><p>function(err, res)</p>
+</dd>
+</dl>
+</div>
+<div class="col-md-6">
+<pre><code class="lang-javascript">var dogapi = require(&quot;dogapi&quot;);
+var options = {
+  api_key: &quot;api_key&quot;,
+  app_key: &quot;app_key&quot;
+};
+dogapi.initialize(options);
+var query = &quot;app&quot;;
+dogapi.search.search(query, function(err, res){
   console.dir(res);
 });
 </code></pre>

--- a/index.html
+++ b/index.html
@@ -1223,10 +1223,10 @@ dogapi.screenboard.share(1234, function(err, res){
 <div class="row">
 <h2 class="bg-primary" style="text-indent:1rem">search</h2></div>
 <ul class="nav nav-pills">
-<li role"presentation"><a href="#search-search">search</a></li>
+<li role"presentation"><a href="#search-query">query</a></li>
 </ul>
-<div class="function row" id="search-search">
-<h3 class="bg-info" style="text-indent:.5rem;padding:.5rem;margin-top:.5rem">search(query, callback)</h3>
+<div class="function row" id="search-query">
+<h3 class="bg-info" style="text-indent:.5rem;padding:.5rem;margin-top:.5rem">query(query, callback)</h3>
 <div class="col-md-6">
 <p>search for metrics and hosts from the past 24 hours</p>
 <h4>Parameters:</h4>
@@ -1247,7 +1247,7 @@ var options = {
 };
 dogapi.initialize(options);
 var query = &quot;app&quot;;
-dogapi.search.search(query, function(err, res){
+dogapi.search.query(query, function(err, res){
   console.dir(res);
 });
 </code></pre>

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -8,6 +8,7 @@ var api = {
     metric: require("./metric"),
     monitor: require("./monitor"),
     screenboard: require("./screenboard"),
+    search: require("./search"),
     serviceCheck: require("./serviceCheck"),
     tag: require("./tag"),
     timeboard: require("./timeboard"),

--- a/lib/api/search.js
+++ b/lib/api/search.js
@@ -15,12 +15,12 @@ var client = require("../client");
  *  };
  *  dogapi.initialize(options);
  *  var query = "app";
- *  dogapi.search.search(query, function(err, res){
+ *  dogapi.search.query(query, function(err, res){
  *    console.dir(res);
  *  });
  *  ```
  */
-function search(query, callback){
+function query(query, callback){
     var params = {
         query: {
             q: query
@@ -30,22 +30,22 @@ function search(query, callback){
 }
 
 module.exports = {
-    search: search,
+    query: query,
     getUsage: function(){
         return [
-            "  dogapi search <query>"
+            "  dogapi search query <query>"
         ];
     },
     getHelp: function(){
         return [
             "Search:",
             "  Subcommands:",
-            "    search <query>    search for hosts and metrics from the last 24 hours"
+            "    query <query>    search for hosts and metrics from the last 24 hours"
         ];
     },
     handleCli: function(subcommand, args, callback){
-        if(subcommand === "search"){
-            search(args["<query>"], callback);
+        if(subcommand === "query" && args._.length > 4){
+            query(args._[4], callback);
         } else {
             callback("unknown subcommand or arguments try `dogapi search --help` for help", false);
         }

--- a/lib/api/search.js
+++ b/lib/api/search.js
@@ -1,0 +1,53 @@
+var client = require("../client");
+
+/*section: search
+ *comment: |
+ *  search for metrics and hosts from the past 24 hours
+ *params:
+ *  query: the seach query to perform (e.g. "app1" or "hosts:app1" or "metrics:response")
+ *  callback: function(err, res)
+ *example: |
+ *  ```javascript
+ *  var dogapi = require("dogapi");
+ *  var options = {
+ *    api_key: "api_key",
+ *    app_key: "app_key"
+ *  };
+ *  dogapi.initialize(options);
+ *  var query = "app";
+ *  dogapi.search.search(query, function(err, res){
+ *    console.dir(res);
+ *  });
+ *  ```
+ */
+function search(query, callback){
+    var params = {
+        query: {
+            q: query
+        }
+    };
+    client.request("GET", "/search", params, callback);
+}
+
+module.exports = {
+    search: search,
+    getUsage: function(){
+        return [
+            "  dogapi search <query>"
+        ];
+    },
+    getHelp: function(){
+        return [
+            "Search:",
+            "  Subcommands:",
+            "    search <query>    search for hosts and metrics from the last 24 hours"
+        ];
+    },
+    handleCli: function(subcommand, args, callback){
+        if(subcommand === "search"){
+            search(args["<query>"], callback);
+        } else {
+            callback("unknown subcommand or arguments try `dogapi search --help` for help", false);
+        }
+    }
+};


### PR DESCRIPTION
Handles #22 

Adding new function `dogapi.search.query` to search for hosts or metrics using the /search api endpoint.

http://docs.datadoghq.com/api/#search