### PR TITLE
Add ability to create embeds

### DIFF
--- a/lib/api/graph.js
+++ b/lib/api/graph.js
@@ -1,4 +1,5 @@
 var client = require("../client");
+var json = require("../json");
 
 /*section: graph
  *comment: take a snapshot of a metric query
@@ -43,8 +44,63 @@ function snapshot(query, from, to, eventQuery, callback){
     client.request("GET", "/graph/snapshot", params, callback);
 }
 
+/*section: graph
+ *comment: create an embed graph of a metric query
+ *params:
+ *  graph_json: The request array to pass create in the embed
+ *  timeframe: (1_hour, 4_hours, 1_day, 2_days, and 1_week)
+ *  size: (small, medium, large, xlarge)
+ *  legend: yes or no
+ *  title: The title of the embed
+ *  callback: function(err, res)
+ *example: |
+ *  ```javascript
+ *  var dogapi = require("dogapi");
+ *  var options = {
+ *    api_key: "api_key",
+ *    app_key: "app_key"
+ *  };
+ *  dogapi.initialize(options);
+ *  var query = "system.cpu.idle{*}";
+ *  var graph_json = {
+ *         "viz": "timeseries",
+ *         "requests": [
+ *           {
+ *             "q": query,
+ *             "aggregator": "avg",
+ *             "conditional_formats": [],
+ *             "type": "area"
+ *           }
+ *         ]
+ *       }
+ *  var timeframe = '1_hour';
+ *  var size = 'xlarge';
+ *  var legend = 'yes';
+ *  var title = 'my awesome embed';
+ *  dogapi.graph.createEmbed(graph_json, timeframe, size, legend, title, function(err, res){
+ *    console.dir(res);
+ *  });
+ *  ```
+ */
+function createEmbed(graph_json, timeframe, size, legend, title, callback){
+    var lastArgument = arguments.length -1;
+
+    var params = {
+        body: 'graph_json=' + JSON.stringify(graph_json) +
+            '&timeframe=' + timeframe +
+            '&size=' + size +
+            '&legend=' + legend +
+            '&title=' + title
+        ,
+        contentType: 'application/x-www-form-urlencoded'
+    };
+
+    client.request("POST", "/graph/embed", params, callback);
+}
+
 module.exports = {
     snapshot: snapshot,
+    createEmbed: createEmbed,
     getUsage: function(){
         return [
             "  dogapi graph snapshot <query> <from> <to> [--events <event-query>]"
@@ -54,18 +110,32 @@ module.exports = {
         return [
             "Graph:",
             "  Subcommands:",
-            "    snapshot <query> <from> <to>    take a snapshot of a graph",
+            "    snapshot <query> <from> <to> --events <event-query>     |     take a snapshot of a graph",
+            "    create_embed --graph_json <graph_json> --timeframe <timeframe> --size <size> --legend <legend> --title <title>     |     create a new graph embed",
             "  Options:",
-            "    --events <event-query>          a query for event bands to add to the snapshot"
+            "    --events <event-query>                     a query for event bands to add to the snapshot",
+            "    --graph_json <graph_json> <required>       The json object to send to the DataDog",
+            "    --timeframe  <timeframe> <required>        The timeframe for the embed (1_hour, 4_hours, 1_day, 2_days, and 1_week)",
+            "    --size <size> <required>                   The size of the graph to create (small, medium, large, xlarge)",
+            "    --legend <legend> <required>               Whether or not to have a legend (yes, no)",
+            "    --title <title> <required>                 The title of the embed to create"
+
         ];
     },
     handleCli: function(subcommand, args, callback){
-        if(args._.length > 5){
+        if (args._.length > 5 && subcommand === "snapshot"){
             var query = args._[4];
             var from = parseInt(args._[5]);
             var to = parseInt(args._[6]);
             var eventQuery = args["events"];
             snapshot(query, from, to, eventQuery, callback);
+        } else if (subcommand === "create_embed") {
+            var graph_json = json.parse(args["graph_json"]);
+            var timeframe = args["timeframe"];
+            var size = args["size"];
+            var legend = args["legend"];
+            var title = args["title"];
+            createEmbed(graph_json, timeframe, size, legend, title, callback);
         } else {
             callback("unknown subcommand or arguments try `dogapi graph --help` for help", false);
         }

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,7 @@ client.prototype.request = function(method, path, params, callback){
     }
 
     params = params || {};
-    var body = (typeof params["body"] === "object")? json.stringify(params["body"]) : params["body"];
+    var body = (typeof params["body"] === "object") ? json.stringify(params["body"]) : params["body"];
     var query = {
         "api_key": this.api_key,
         "application_key": this.app_key,
@@ -79,7 +79,7 @@ client.prototype.request = function(method, path, params, callback){
 
     if(["POST", "PUT"].indexOf(http_options["method"]) >= 0){
         http_options["headers"] = {
-            "Content-Type": "application/json",
+            "Content-Type": params["contentType"] ? params["contentType"] : "application/json",
             "Content-Length": body.length,
         };
     }


### PR DESCRIPTION
This adds an embed function onto the graphs api. This allows a user to create any graph_json they desire from this api. 

If there is something you would like for me to change, let me know. 

Should probably add the rest of the embed functioanlity as well. maybe I should even rename the function embed to createEmbed and then add a getEmbeds and getEmbed function to match the DataDog api more closely. This could be done in a separate PR however. 