### PR TITLE
Add tests and update CLI signature for graph.createEmbed

### DIFF
--- a/lib/api/graph.js
+++ b/lib/api/graph.js
@@ -1,5 +1,7 @@
 var client = require("../client");
+var extend = require("extend");
 var json = require("../json");
+var querystring = require("querystring");
 
 /*section: graph
  *comment: take a snapshot of a metric query
@@ -48,10 +50,11 @@ function snapshot(query, from, to, eventQuery, callback){
  *comment: create an embed graph of a metric query
  *params:
  *  graph_json: The request array to pass create in the embed
- *  timeframe: (1_hour, 4_hours, 1_day, 2_days, and 1_week)
- *  size: (small, medium, large, xlarge)
- *  legend: yes or no
- *  title: The title of the embed
+ *  options: optional, object of extra parameters to pass to the embed create (see options[*] params)
+ *  options["timeframe"]: optional, one of ("1_hour", "4_hours", "1_day", "2_days", and "1_week")
+ *  options["size"]: optional, one of ("small", "medium", "large", "xlarge")
+ *  options["legend"]: optional, "yes" or "no"
+ *  options["title"]: optional, the title of the embed
  *  callback: function(err, res)
  *example: |
  *  ```javascript
@@ -62,37 +65,44 @@ function snapshot(query, from, to, eventQuery, callback){
  *  };
  *  dogapi.initialize(options);
  *  var query = "system.cpu.idle{*}";
- *  var graph_json = {
- *         "viz": "timeseries",
- *         "requests": [
+ *  var graphJSON = {
+ *         viz: "timeseries",
+ *         requests: [
  *           {
- *             "q": query,
- *             "aggregator": "avg",
- *             "conditional_formats": [],
- *             "type": "area"
+ *             q: query,
+ *             aggregator: "avg",
+ *             conditional_formats: [],
+ *             type: "area"
  *           }
  *         ]
  *       }
- *  var timeframe = '1_hour';
- *  var size = 'xlarge';
- *  var legend = 'yes';
- *  var title = 'my awesome embed';
- *  dogapi.graph.createEmbed(graph_json, timeframe, size, legend, title, function(err, res){
+ *  var options = {
+ *      timeframe: "1_hour",
+ *      size: "xlarge",
+ *      legend: "yes",
+ *      title: "my awesome embed"
+ *  };
+ *  dogapi.graph.createEmbed(graphJSON, options, function(err, res){
  *    console.dir(res);
  *  });
  *  ```
  */
-function createEmbed(graph_json, timeframe, size, legend, title, callback){
-    var lastArgument = arguments.length -1;
+function createEmbed(graphJSON, options, callback){
+    if(callback === undefined && typeof options === 'function'){
+        callback = options;
+        options = {};
+    }
+    var body = {
+        graph_json: JSON.stringify(graphJSON)
+    };
+    // Use `extend` to merge `options` into `body`
+    // DEV: `extend` will ignore any properties whose value is `undefined`
+    extend(body, options || {});
 
+    // Create the request
     var params = {
-        body: 'graph_json=' + JSON.stringify(graph_json) +
-            '&timeframe=' + timeframe +
-            '&size=' + size +
-            '&legend=' + legend +
-            '&title=' + title
-        ,
-        contentType: 'application/x-www-form-urlencoded'
+        body: querystring.stringify(body),
+        contentType: "application/x-www-form-urlencoded"
     };
 
     client.request("POST", "/graph/embed", params, callback);
@@ -103,7 +113,8 @@ module.exports = {
     createEmbed: createEmbed,
     getUsage: function(){
         return [
-            "  dogapi graph snapshot <query> <from> <to> [--events <event-query>]"
+            "  dogapi graph snapshot <query> <from> <to> [--events <event-query>]",
+            "  dogapi graph create_embed <graph_json> [--timeframe <timeframe>] [--size <size>] [--legend <legend>] [--title <title>]"
         ];
     },
     getHelp: function(){
@@ -111,14 +122,13 @@ module.exports = {
             "Graph:",
             "  Subcommands:",
             "    snapshot <query> <from> <to> --events <event-query>     |     take a snapshot of a graph",
-            "    create_embed --graph_json <graph_json> --timeframe <timeframe> --size <size> --legend <legend> --title <title>     |     create a new graph embed",
+            "    create_embed <graph_json> --timeframe <timeframe> --size <size> --legend <legend> --title <title>     |     create a new graph embed",
             "  Options:",
-            "    --events <event-query>                     a query for event bands to add to the snapshot",
-            "    --graph_json <graph_json> <required>       The json object to send to the DataDog",
-            "    --timeframe  <timeframe> <required>        The timeframe for the embed (1_hour, 4_hours, 1_day, 2_days, and 1_week)",
-            "    --size <size> <required>                   The size of the graph to create (small, medium, large, xlarge)",
-            "    --legend <legend> <required>               Whether or not to have a legend (yes, no)",
-            "    --title <title> <required>                 The title of the embed to create"
+            "    --events <event-query>          a query for event bands to add to the snapshot",
+            "    --timeframe  <timeframe>        The timeframe for the embed (1_hour, 4_hours, 1_day, 2_days, and 1_week)",
+            "    --size <size>                   The size of the graph to create (small, medium, large, xlarge)",
+            "    --legend <legend>               Whether or not to have a legend (yes, no)",
+            "    --title <title>                 The title of the embed to create"
 
         ];
     },
@@ -129,13 +139,15 @@ module.exports = {
             var to = parseInt(args._[6]);
             var eventQuery = args["events"];
             snapshot(query, from, to, eventQuery, callback);
-        } else if (subcommand === "create_embed") {
-            var graph_json = json.parse(args["graph_json"]);
-            var timeframe = args["timeframe"];
-            var size = args["size"];
-            var legend = args["legend"];
-            var title = args["title"];
-            createEmbed(graph_json, timeframe, size, legend, title, callback);
+        } else if (args._.length > 4 && subcommand === "create_embed") {
+            var graph_json = json.parse(args._[4]);
+            var options = {
+                timeframe: args["timeframe"],
+                size: args["size"],
+                legend: args["legend"],
+                title: args["title"]
+            };
+            createEmbed(graph_json, options, callback);
         } else {
             callback("unknown subcommand or arguments try `dogapi graph --help` for help", false);
         }

--- a/test/api/graph.js
+++ b/test/api/graph.js
@@ -1,0 +1,84 @@
+var assert = require("assert");
+var client = require("../../lib/client");
+var extend = require("extend");
+var graph = require("../../lib/api/graph");
+var sinon = require("sinon");
+var querystring = require("querystring");
+
+describe("api/graph", function(){
+    var stub_request;
+    beforeEach(function(){
+        // Setup `client.request` as a stub
+        stub_request = sinon.stub(client, "request");
+    });
+    afterEach(function(){
+        // Reset the original `client.request`
+        stub_request.restore();
+        stub_request = null;
+    });
+    describe("#creaetEmbed", function(){
+        it("should make a valid api call", function(){
+            var graphJSON = {
+                viz: "timeseries",
+                requests: [
+                    {
+                        q: "system.cpu.idle{*}"
+                    }
+                ]
+            };
+            var options = {
+                timeframe: "1_hour",
+                size: "large",
+                legend: "yes",
+                title: "test graph embed"
+            };
+
+            // Make our api call
+            graph.createEmbed(graphJSON, options);
+
+            // Assert we properly called `client.request`
+            assert(stub_request.calledOnce);
+            var call_args = stub_request.getCall(0).args;
+            // Method and endpoint are correct
+            assert.equal(call_args[0], "POST");
+            assert.equal(call_args[1], "/graph/embed");
+
+            // Properly formatted body and content-type
+            var params = call_args[2];
+            var expectedBody = {
+                graph_json: JSON.stringify(graphJSON),
+                timeframe: "1_hour",
+                size: "large",
+                legend: "yes",
+                title: "test graph embed"
+            };
+            assert.deepEqual(querystring.parse(params.body), expectedBody);
+            assert(params.contentType, "application/x-form-urlencoded");
+        });
+
+        it("should only require graph_json", function(){
+            var graphJSON = {
+                viz: "timeseries",
+                requests: [
+                    {
+                        q: "system.cpu.idle{*}"
+                    }
+                ]
+            };
+
+            // Make our api call
+            graph.createEmbed(graphJSON);
+
+            // Assert we properly called `client.request`
+            assert(stub_request.calledOnce);
+            var call_args = stub_request.getCall(0).args;
+
+            // Properly formatted body
+            var params = call_args[2];
+            var expectedBody = {
+                graph_json: JSON.stringify(graphJSON)
+            };
+            assert.deepEqual(querystring.parse(params.body), expectedBody);
+        });
+    });
+});


### PR DESCRIPTION
There were a few small tweaks we wanted to make to the new graph create embed code.

* Add in tests (at least very basic ones)
* Update styles to match the rest of the codebase
* Update CLI to make some parameters required and other optional
* URI encode all values when building the form body to post