### PR TITLE
Fix sending of metric_type for dogapi.metric.send

### DIFF
--- a/lib/api/metric.js
+++ b/lib/api/metric.js
@@ -12,7 +12,7 @@ var client = require("../client");
  *    optional, object which can contain the following keys
  *    * host: the host source of the metric
  *    * tags: array of "tag:value"'s to use for the metric
- *    * metric_type: which metric type to use ("gauge" or "counter") [default: gauge]
+ *    * metric_type|type: which metric type to use ("gauge" or "counter") [default: gauge]
  *  callback: |
  *    function(err, res)
  *example: |
@@ -33,6 +33,9 @@ var client = require("../client");
  *  dogapi.metric.send("my.metric", [[now, 1000]], function(err, results){
  *    console.dir(results);
  *  });
+ *  dogapi.metric.send("my.counter", 5, {type: "counter"}, function(err, results){
+ *    console.dir(results);
+ *  });
  *  ```
  */
 function send(metric, points, extra, callback){
@@ -47,7 +50,8 @@ function send(metric, points, extra, callback){
             points: points,
             host: extra.host,
             tags: extra.tags,
-            metric_type: extra.metric_type
+            // DEV: For backwards compatibility, allow `metric_type`
+            type: extra.type || extra.metric_type
         }
     ];
 
@@ -64,7 +68,7 @@ function send(metric, points, extra, callback){
  *    * points: a single data point (e.g. `50`), an array of data points (e.g. `[50, 100]`) or an array of `[timestamp, value]` elements (e.g. `[[now, 50], [now, 100]]`)
  *    * tags: an array of "tag:value"'s
  *    * host: the source hostname to use for the metrics
- *    * metric_type: the type of metric to use ("gauge" or "counter") [default: gauge]
+ *    * metric_type|type: the type of metric to use ("gauge" or "counter") [default: gauge]
  *  callback: |
  *    function(err, res)
  *example: |
@@ -121,6 +125,12 @@ function send_all(metrics, callback){
         });
 
         metrics[i].points = points;
+
+        // DEV: Change `metric_type` to `type` for backwards compatibility
+        metrics[i].type = metrics[i].type || metrics[i].metric_type;
+        // Remove `metric_type` if it was set
+        // DEV: This will not cause an error if `metric_type` does not exist
+        delete metrics[i].metric_type;
     }
 
     var params = {


### PR DESCRIPTION
Fix for #35 

It appears that the Datadog API used to support sending of `metric_type`, now it is just `type`.

In this PR, we are making sure to allow both `metric_type` and `type`, but under the covers converting `metric_type` to `type`.

/cc @jetmind