### PR TITLE
Fix 'dogapi metric send' cli command

### DIFF
--- a/lib/api/metric.js
+++ b/lib/api/metric.js
@@ -200,18 +200,14 @@ module.exports = {
         ]
     },
     handleCli: function(subcommand, args, callback){
-        if(subcommand === "send"){
+        if(args._.length > 5 && subcommand === "send"){
             var extra = {};
-            if(args["--tags"]){
-                extra.tags = args["--tags"].split(",");
+            if(args.tags){
+                extra.tags = args.tags.split(",");
             }
-            if(args["--host"]){
-                extra.host = args["--host"];
-            }
-            if(args["--type"]){
-                extra.metric_type = args["--type"];
-            }
-            send(args["<metric>"], args["<point>"], extra, callback);
+            extra.host = args.host;
+            extra.type = args.type;
+            send(args._[4], args._[5], extra, callback);
         } else if(subcommand === "query" && args._.length > 6){
             var from = parseInt(args._[4]);
             var to = parseInt(args._[5]);


### PR DESCRIPTION
While testing #37 I noticed that the cli command for `dogapi metric send` was not working as expected.

This PR fixes the issues with submitting metrics via the cli.
