### PR TITLE
Use Buffer.byteLength to get Content-Length

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -80,7 +80,7 @@ client.prototype.request = function(method, path, params, callback){
     if(["POST", "PUT"].indexOf(http_options["method"]) >= 0){
         http_options["headers"] = {
             "Content-Type": params["contentType"] ? params["contentType"] : "application/json",
-            "Content-Length": body.length,
+            "Content-Length": Buffer.byteLength(body),
         };
     }
 


### PR DESCRIPTION
Hi, @brettlangdon 
I'm sorry that this topic is unfamiliar for english-speaking people. When created new datadog event, I've gotten following error.

```
<Invalid JSON structure>
```

I think this cause is that this library uses `String.length`. See example.

```javascript
> '☆'.length
1
> Buffer.byteLength('☆')
3
```

So datadog server considers to Content-Length is shorter than real body size, and failed to parse POST body. thanks.