### PR TITLE
Explicitly initialize points

### DIFF
--- a/lib/api/metric.js
+++ b/lib/api/metric.js
@@ -109,7 +109,7 @@ function send_all(metrics, callback){
         //   500 => [500]
         //   [500, 100] => [[<timestamp>, 500], [<timestamp>, 1000]]
         //   [[<timestamp>, 500]] => [[<timestamp>, 500]]
-        points = metrics[i].points
+        var points = metrics[i].points;
         if(!Array.isArray(metrics[i].points)){
             points = [points];
         }


### PR DESCRIPTION
Apart from being a stylistic change, this change also fixes a critical bug I encountered (resulting in `points` being undefined and the program crashing) when running this in production – basically, after being minified, it didn't work any more.