### PR TITLE
Add screenboard update API

### DIFF
--- a/index.html
+++ b/index.html
@@ -1177,6 +1177,7 @@ dogapi.monitor.unmuteAll(function(err, res){
 <h2 class="bg-primary" style="text-indent:1rem">screenboard</h2></div>
 <ul class="nav nav-pills">
 <li role"presentation"><a href="#screenboard-create">create</a></li>
+<li role"presentation"><a href="#screenboard-update">update</a></li>
 <li role"presentation"><a href="#screenboard-remove">remove</a></li>
 <li role"presentation"><a href="#screenboard-get">get</a></li>
 <li role"presentation"><a href="#screenboard-getAll">getAll</a></li>
@@ -1245,6 +1246,72 @@ var options = {
 };
 dogapi.screenboard.create(
   boardTitle, widgets, options,
+  function(err, res){
+    console.dir(res);
+  }
+);
+</code></pre>
+</div>
+</div>
+<div class="function row" id="screenboard-update">
+<h3 class="bg-info" style="text-indent:.5rem;padding:.5rem;margin-top:.5rem">update(boardId, boardTitle, widgets, options, callback)</h3>
+<div class="col-md-6">
+<p>update an existing screenboard</p>
+<h4>Parameters:</h4>
+<dl>
+<dt>boardId</dt>
+<dd><p>the id of the screenboard to update</p>
+</dd>
+<dt>boardTitle</dt>
+<dd><p>the name of the screenboard</p>
+</dd>
+<dt>widgets</dt>
+<dd><p>an array of widgets, see <a href="http://docs.datadoghq.com/api/screenboards/">http://docs.datadoghq.com/api/screenboards/</a> for more info</p>
+</dd>
+<dt>options</dt>
+<dd><p><em>optional</em>, a object which can contain any of the following keys</p>
+<ul>
+<li>description: description of the screenboard</li>
+<li>templateVariables: |
+an array of objects with the following keys<ul>
+<li>name: the name of the variable</li>
+<li>prefix: <em>optional</em>, the tag prefix for this variable</li>
+<li>default: <em>optional</em>, the default value for this tag</li>
+</ul>
+</li>
+<li>width: the width of the screenboard in pixels</li>
+<li>height: the height of the screenboard in pixels</li>
+<li>readOnly: the read-only status of the screenboard</li>
+</ul>
+</dd>
+<dt>callback</dt>
+<dd><p>function(err, res)</p>
+</dd>
+</dl>
+</div>
+<div class="col-md-6">
+<pre><code class="lang-javascript">var dogapi = require(&quot;dogapi&quot;);
+var options = {
+  api_key: &quot;api_key&quot;,
+  app_key: &quot;app_key&quot;
+};
+dogapi.initialize(options);
+var boardTitle = &quot;my screenboard&quot;;
+var widgets = [
+  {
+    type: &quot;image&quot;,
+    height: 20,
+    width: 32,
+    y: 7,
+    x: 32,
+    url: &quot;https://path/to/image.jpg&quot;
+  }
+];
+var options = {
+  description: &quot;it is super awesome&quot;
+};
+dogapi.screenboard.update(
+  1234, boardTitle, widgets, options,
   function(err, res){
     console.dir(res);
   }

--- a/lib/api/screenboard.js
+++ b/lib/api/screenboard.js
@@ -93,6 +93,89 @@ function create(boardTitle, widgets, options, callback){
 }
 
 /*section: screenboard
+ *comment: update an existing screenboard
+ *params:
+ *  boardId: the id of the screenboard to update
+ *  boardTitle: the name of the screenboard
+ *  widgets: an array of widgets, see http://docs.datadoghq.com/api/screenboards/ for more info
+ *  options: |
+ *    optional, a object which can contain any of the following keys
+ *    * description: description of the screenboard
+ *    * templateVariables: |
+ *      an array of objects with the following keys
+ *      * name: the name of the variable
+ *      * prefix: optional, the tag prefix for this variable
+ *      * default: optional, the default value for this tag
+ *    * width: the width of the screenboard in pixels
+ *    * height: the height of the screenboard in pixels
+ *    * readOnly: the read-only status of the screenboard
+ *  callback: function(err, res)
+ *example: |
+ *  ```javascript
+ *  var dogapi = require("dogapi");
+ *  var options = {
+ *    api_key: "api_key",
+ *    app_key: "app_key"
+ *  };
+ *  dogapi.initialize(options);
+ *  var boardTitle = "my screenboard";
+ *  var widgets = [
+ *    {
+ *      type: "image",
+ *      height: 20,
+ *      width: 32,
+ *      y: 7,
+ *      x: 32,
+ *      url: "https://path/to/image.jpg"
+ *    }
+ *  ];
+ *  var options = {
+ *    description: "it is super awesome"
+ *  };
+ *  dogapi.screenboard.update(
+ *    1234, boardTitle, widgets, options,
+ *    function(err, res){
+ *      console.dir(res);
+ *    }
+ *  );
+ *  ```
+ */
+function update(boardId, boardTitle, widgets, options, callback) {
+  if(arguments.length < 5 && typeof arguments[3] === "function"){
+      callback = options;
+      options = {};
+  }
+  if(typeof options !== "object"){
+      options = {};
+  }
+
+  var params = {
+      body: {
+          board_title: boardTitle,
+          widgets: widgets
+      }
+  };
+
+  if(options.description){
+      params.body.description = options.description;
+  }
+  if(options.templateVariables){
+      params.body.template_variables = options.templateVariables;
+  }
+  if(options.width){
+      params.body.width = options.width;
+  }
+  if(options.height){
+      params.body.height = options.height;
+  }
+  if(options.readOnly){
+      params.body.read_only = options.readOnly;
+  }
+
+  client.request("PUT", "/screen", params, callback);
+}
+
+/*section: screenboard
  *comment: delete an existing screenboard
  *params:
  *  boardId: the id of the screenboard to delete
@@ -183,6 +266,7 @@ function share(boardId, callback){
 module.exports = {
     create: create,
     remove: remove,
+    update: update,
     get: get,
     getAll: getAll,
     share: share,
@@ -200,6 +284,7 @@ module.exports = {
             "Screenboard:",
             "  Subcommands:",
             "    create <boardTitle> <widgets>           create a new screenboard, <widgets> is a json of the graph definition",
+            "    update <boardId> <boardTitle> <widgets> update a screenboard",
             "    remove <boardId>                        remove an existing screenboard",
             "    get <boardId>                           get an existing screenboard",
             "    getall                                  get all screenboards",
@@ -220,6 +305,26 @@ module.exports = {
             remove(args._[4], callback);
         } else if(subcommand === "share"){
             share(args._[4], callback);
+        } else if (subcommand === "update"){
+            var boardId = args._[4];
+            var boardTitle = args._[5];
+            var widgets = json.parse(args._[6]);
+
+            var options = {};
+            if(args["description"]) {
+                options.description = args["description"];
+            }
+            if(args["tmpvars"]){
+                options.templateVariables = json.parse(args["tmpvars"]);
+            }
+            if(args["width"]){
+                options.width = parseInt(args["width"]);
+            }
+            if(args["height"]){
+                options.height = parseInt(args["height"]);
+            }
+
+            update(boardId, boardTitle, widgets, options, callback);
         } else if(subcommand === "create"){
             var boardTitle = args._[4];
             var widgets = json.parse(args._[5]);


### PR DESCRIPTION
Datadog now has a screenboard update API.
- I used the same parameters as the create call + boardId.
- Also ran `npm run docs`