### PR TITLE
Fix mute/unmute for hosts and monitors

### DIFF
--- a/lib/api/host.js
+++ b/lib/api/host.js
@@ -43,7 +43,6 @@ function mute(hostname, options, callback){
     client.request("POST", util.format("/host/%s/mute", hostname), params, callback);
 }
 
-
 /*section: host
  *comment: unmute the given host, if it is not already unmuted
  *params:

--- a/lib/api/host.js
+++ b/lib/api/host.js
@@ -1,4 +1,5 @@
 var client = require("../client");
+var util = require("util");
 
 /*section: host
  *comment: mute the given host, if it is not already muted
@@ -27,21 +28,21 @@ function mute(hostname, options, callback){
         callback = options;
         options = {};
     }
-    var params = {
-        body: {
-            hostname: hostname
-        }
-    };
+    var params = {};
     if(typeof options === "object"){
+        params.body = {};   // create body property
         if(options.end){
             params.body.end = parseInt(options.end);
         }
         if(options.override){
             params.body.override = options.override;
         }
+    } else {
+        params.body = "";   // create empty body
     }
-    client.request("POST", "/host", params, callback);
+    client.request("POST", util.format("/host/%s/mute", hostname), params, callback);
 }
+
 
 /*section: host
  *comment: unmute the given host, if it is not already unmuted
@@ -62,12 +63,8 @@ function mute(hostname, options, callback){
  *  ```
  */
 function unmute(hostname, callback){
-    var params = {
-        body: {
-            hostname: hostname
-        }
-    };
-    client.request("POST", "/host", params, callback);
+    var params = {body: ""};    // create empty body
+    client.request("POST", util.format("/host/%s/unmute", hostname), params, callback);
 }
 
 module.exports = {

--- a/lib/api/monitor.js
+++ b/lib/api/monitor.js
@@ -294,10 +294,15 @@ function unmute(monitorId, scope, callback){
             scope: scope
         };
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
     } else {
         params.body = "";  // create empty body
 >>>>>>> 5243bf7... add params.body default to client.prototype.request
+=======
+    } else {
+        params.body = "";
+>>>>>>> 4818053... add params.body default to mute() and unmute()
     }
     client.request("POST", util.format("/monitor/%s/unmute", monitorId), params, callback);
 }

--- a/lib/api/monitor.js
+++ b/lib/api/monitor.js
@@ -240,7 +240,7 @@ function mute(monitorId, options, callback){
     } else {
         params.body = "";  // create empty body
     }
-    client.request("POST", util.format("/monitor/%s/mute"), params, callback);
+    client.request("POST", util.format("/monitor/%s/mute", monitorId), params, callback);
 }
 
 /*section: monitor
@@ -293,16 +293,8 @@ function unmute(monitorId, scope, callback){
         params.body = {
             scope: scope
         };
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
     } else {
         params.body = "";  // create empty body
->>>>>>> 5243bf7... add params.body default to client.prototype.request
-=======
-    } else {
-        params.body = "";
->>>>>>> 4818053... add params.body default to mute() and unmute()
     }
     client.request("POST", util.format("/monitor/%s/unmute", monitorId), params, callback);
 }

--- a/lib/api/monitor.js
+++ b/lib/api/monitor.js
@@ -237,6 +237,8 @@ function mute(monitorId, options, callback){
         if(options.end){
             params.body.end = parseInt(options.end);
         }
+    } else {
+        params.body = "";  // create empty body
     }
     client.request("POST", util.format("/monitor/%s/mute"), params, callback);
 }
@@ -291,6 +293,11 @@ function unmute(monitorId, scope, callback){
         params.body = {
             scope: scope
         };
+<<<<<<< HEAD
+=======
+    } else {
+        params.body = "";  // create empty body
+>>>>>>> 5243bf7... add params.body default to client.prototype.request
     }
     client.request("POST", util.format("/monitor/%s/unmute", monitorId), params, callback);
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -49,10 +49,9 @@ var client = function(){
 client.prototype.request = function(method, path, params, callback){
     if(arguments.length === 3 && typeof arguments[2] === "function"){
         callback = arguments[2];
-        params = {};
+        params = {body: ''};  // create params with empty body property
     }
 
-    params = params || {};
     var body = (typeof params["body"] === "object") ? json.stringify(params["body"]) : params["body"];
     var query = {
         "api_key": this.api_key,


### PR DESCRIPTION
Hey I'm using this library to build a hubot plugin for Datadog and patched some bugs.  
- muting/unmuting hosts fails
  - FIX: Added the hostname to path when calling client.request().  Datadog's host api endpoint now takes the hostname to mute/umute in the url instead of the POST body.  This also means params needs to be passed to client.request() with at least an empty body 
- muting monitors fails
  - FIX: Added the missing monitorId to the client.request() call in monitor.mute().  monitorId wasn't getting passed.
- unmuting monitors fails
  - FIX: Added an empty params.body to monitor.unmute().  Params wasn't getting a body set and was failing at req.write(body)

  