### PR TITLE
Supporting tags for monitors

### DIFF
--- a/lib/api/monitor.js
+++ b/lib/api/monitor.js
@@ -10,6 +10,7 @@ var util = require("util");
  *    optional, an object containing any of the following
  *    * name: the name of the monitor
  *    * message: the message for the monitor
+ *    * tags: a list of strings as tags to associate with the monitor
  *    * options: an object, to see available options please see the [monitor create](http://docs.datadoghq.com/api/#monitor-create) docs
  *  callback: function(err, res)
  *example: |
@@ -46,6 +47,9 @@ function create(type, query, properties, callback){
         }
         if(properties.message){
             params.body.message = properties.message;
+        }
+        if(properties.tags){
+            params.body.tags = properties.tags;
         }
         if(typeof properties.options === "object"){
             params.body.options = properties.options;

--- a/lib/api/monitor.js
+++ b/lib/api/monitor.js
@@ -137,6 +137,7 @@ function getAll(options, callback){
  *    optional, an object containing any of the following
  *    * name: the name of the monitor
  *    * message: the message for the monitor
+ *    * tags: a list of strings as tags to associate with the monitor
  *    * options: an object, to see available options please see the [monitor create](http://docs.datadoghq.com/api/#monitor-create) docs
  *  callback: function(err, res)
  *example: |
@@ -171,6 +172,9 @@ function update(monitorId, query, properties, callback){
         }
         if(properties.message){
             params.body.message = properties.message;
+        }
+        if(properties.tags){
+            params.body.tags = properties.tags;
         }
         if(typeof properties.options === "object"){
             params.body.options = properties.options;

--- a/lib/api/monitor.js
+++ b/lib/api/monitor.js
@@ -100,6 +100,7 @@ function get(monitorId, groupStates, callback){
  *    optional, an object containing any of the following
  *    * group_states: an array containing any of the following "all", "alert", "warn", or "no data"
  *    * tags: an array of "tag:value"'s to filter on
+ *    * monitor_tags: a comma separated list indicating what service and/or custom tags
  *  callback: function(err, res)
  *example: |
  *  ```javascript
@@ -127,6 +128,9 @@ function getAll(options, callback){
         }
         if(options.tags){
             params.query.tags = options.tags.join(",");
+        }
+        if(options.monitor_tags){
+            params.query.monitor_tags = options.monitor_tags.join(",");
         }
     }
     client.request("GET", "/monitor", params, callback);


### PR DESCRIPTION
Hey,
Based on DataDog API [document](http://docs.datadoghq.com/api/#monitors), monitors are now able to have tags optionally. 

This PR is trying to enable this feature upon creation, modification and retrieving monitors.