### PR TITLE
The Screenboard Update API call requires the boardID

### DIFF
--- a/lib/api/screenboard.js
+++ b/lib/api/screenboard.js
@@ -172,7 +172,7 @@ function update(boardId, boardTitle, widgets, options, callback) {
       params.body.read_only = options.readOnly;
   }
 
-  client.request("PUT", "/screen", params, callback);
+  client.request("PUT", util.format("/screen/%s", boardId), params, callback);
 }
 
 /*section: screenboard


### PR DESCRIPTION
url path must be -> /screen/{boardId}
as per:
https://docs.datadoghq.com/api/?lang=bash#update-a-screenboard