### PR TITLE
Set Unknown Error as Default for Response Ending Rather than Null

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -98,7 +98,7 @@ client.prototype.request = function(method, path, params, callback){
         });
 
         res.on("end", function(){
-            var error = null;
+            var error = new Error("An unknown error occurred");
             try{ data = json.parse(data); }catch(e){}
             if(data["errors"]){
                 error = data["errors"];


### PR DESCRIPTION
Currently, it's possible for requests that end to send a `null` error on the error callback if data isn't written to the error as intended. This can cause consumers of the error callback to get tripped up if they're expecting an `Error` and receive `null` instead. To mitigate this, we should be returning an unknown `Error` instead as a fallback. Without this, `null` can cause system errors and crashes if not handled properly.